### PR TITLE
added  `suppressHydrationWarning` due to annoying console error

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-svh bg-tertiary font-sans`}>
         <Toast />
         <Providers>{children}</Providers>


### PR DESCRIPTION
Note that ThemeProvider is a client component, not a server component. 

> Note! If you do not add [suppressHydrationWarning](https://reactjs.org/docs/dom-elements.html#suppresshydrationwarning:~:text=It%20only%20works%20one%20level%20deep) to your <html> you will get warnings because next-themes updates that element. This property only applies one level deep, so it won't block hydration warnings on other elements.

[Source](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app)